### PR TITLE
fix: only generate one style in head

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,17 +124,20 @@ function addTags(tags: string[]) {
     }
 
     function mockClasses() {
-      const completions = generateCompletions(processor)
-      const comment = '/* Windi CSS mock class names for devtools auto-completion */\n'
-      const css = [
-        ...completions.color,
-        ...completions.static,
-      ].map(toClass).join('')
+      if (!document.getElementById("windicss-devtools-completions")) {
+        const completions = generateCompletions(processor)
+        const comment = '/* Windi CSS mock class names for devtools auto-completion */\n'
+        const css = [
+          ...completions.color,
+          ...completions.static,
+        ].map(toClass).join('')
 
-      const style = document.createElement('style')
-      style.setAttribute('type', 'text/css')
-      style.innerHTML = comment + css
-      document.head.prepend(style)
+        const style = document.createElement('style')
+        style.setAttribute('type', 'text/css')
+        style.id = "windicss-devtools-completions";
+        style.innerHTML = comment + css
+        document.head.prepend(style)
+      }
     }
 
     function extractAll() {


### PR DESCRIPTION
if script is injected in multiple components (needed for HMR in svelte)
it would generate multiple style tags, since it is running multiple times. so check to if it exists, otherwise add it